### PR TITLE
Ajustar estilos css carrusel móvil

### DIFF
--- a/ccs-2.css
+++ b/ccs-2.css
@@ -2172,3 +2172,47 @@ html, body { overflow-x: hidden; }
 .swiper-pagination-bullet {
   background: #c49b3f !important;
 }
+/* ===== Mobile-only carousel fixes (<=768px) ===== */
+@media (max-width: 768px) {
+  /* Prevent overflow and allow intrinsic height based on image ratio */
+  .carousel-container,
+  .gallery-section .carousel-container {
+    max-width: 100vw !important;
+    width: 100% !important;
+  }
+
+  .carousel-track {
+    align-items: center !important;
+    gap: 0 !important;
+  }
+
+  /* Remove rigid heights on mobile and cap to viewport height */
+  .carousel-item,
+  .gallery-section .carousel-item {
+    height: auto !important;
+    max-height: 100vh !important;
+    display: flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+  }
+
+  /* Show full image without distortion; never exceed device width/height */
+  .carousel-item img,
+  .gallery-section .carousel-item img {
+    width: 100% !important;
+    max-width: 100vw !important;
+    height: auto !important;
+    max-height: 100vh !important;
+    object-fit: contain !important;
+    object-position: center center !important;
+    display: block !important;
+    margin: 0 auto !important;
+  }
+
+  /* Keep nav buttons vertically centered regardless of dynamic heights */
+  .carousel-prev,
+  .carousel-next {
+    top: 50% !important;
+    transform: translateY(-50%) !important;
+  }
+}


### PR DESCRIPTION
Adjusts carousel CSS for mobile devices to ensure images fit, are centered, and navigation buttons remain aligned.

---
<a href="https://cursor.com/background-agent?bcId=bc-c296a963-1f99-4a00-84c9-5a62e234cdc9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c296a963-1f99-4a00-84c9-5a62e234cdc9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

